### PR TITLE
Fix range conversion

### DIFF
--- a/src/convert-expression/range-conversion.js
+++ b/src/convert-expression/range-conversion.js
@@ -2,7 +2,8 @@
 module.exports = (function() {
   function replaceWithRange(expression, text, init, end) {
     var numbers = [];
-    for(var i = init; i <= end; i++) {
+    var last = parseInt(end);
+    for(var i = parseInt(init); i <= last; i++) {
       numbers.push(i);
     }
     return expression.replace(new RegExp(text, 'gi'), numbers.join());

--- a/test/convert-expression/range-conversion-test.js
+++ b/test/convert-expression/range-conversion-test.js
@@ -9,4 +9,10 @@ describe('range-conversion.js', function() {
     var expression = conversion(expressions).join(' ');
     expect(expression).to.equal('0,1,2,3 0,1,2,3 0,1,2 1,2,3 1,2 0,1,2,3');
   });
+
+  it('shuld convert ranges to numbers', function() {
+    var expressions = '0-3 0-3 8-10 1-3 1-2 0-3'.split(' ');
+    var expression = conversion(expressions).join(' ');
+    expect(expression).to.equal('0,1,2,3 0,1,2,3 8,9,10 1,2,3 1,2 0,1,2,3');
+  });
 });

--- a/test/task-hour-test.js
+++ b/test/task-hour-test.js
@@ -68,6 +68,23 @@ describe('Task', function(){
       task.update(date);
       expect(2).to.equal(task.executed);
     });
+
+    it('should run every hour on range', function(){
+      var task = new Task('* 8-20 * * *', function(){
+        this.executed += 1;
+      });
+      task.executed = 0;
+      var date = new Date(2016, 1, 1);
+      date.setHours(0);
+      task.update(date);
+      date.setHours(8);
+      task.update(date);
+      date.setHours(19);
+      task.update(date);
+      date.setHours(21);
+      task.update(date);
+      expect(2).to.equal(task.executed);
+    });
   });
 });
 

--- a/test/validate-hours-test.js
+++ b/test/validate-hours-test.js
@@ -30,5 +30,11 @@ describe('pattern-validation.js', function(){
         validate('* */2 * * *');
       }).to.not.throwException();
     });
+
+    it('should accept range for hours', function(){
+      expect(function(){
+        validate('* 3-20 * * *');
+      }).to.not.throwException();
+    });
   });
 });


### PR DESCRIPTION
Range is not converted correctly.

When `range-conversion.js` tries to convert a range like `3-5` it uses `3` and `5` as string rather than convert it to int values and this causes the repeat loop is not executed, so the numbers` [3, 4, 5]` to replace are not provided.