### PR TITLE
validation for string type added on validate Function

### DIFF
--- a/src/pattern-validation.js
+++ b/src/pattern-validation.js
@@ -41,6 +41,9 @@ module.exports = ( function(){
   }
 
   function validate(pattern){
+    if (pattern.constructor != String) {
+      throw new Error('Expression must be of type "String"');
+    }
     var patterns = pattern.split(' ');
     var executablePattern = convertExpression(pattern);
     var executablePatterns = executablePattern.split(' ');

--- a/src/pattern-validation.js
+++ b/src/pattern-validation.js
@@ -41,7 +41,7 @@ module.exports = ( function(){
   }
 
   function validate(pattern){
-    if (pattern.constructor != String) {
+    if (pattern.constructor !== String) {
       throw new Error('Expression must be of type "String"');
     }
     var patterns = pattern.split(' ');


### PR DESCRIPTION
when the pattern was not of type String, the validate function fails as the _split_ function can only be called on _String_ #45 