### PR TITLE
Expose public .validate() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,17 @@ var task = cron.schedule('* * * * *', function() {
 task.destroy();
 ```
 
+### Validate
+
+Validate that the given string is a valid cron expression.
+
+```javascript
+var cron = require('node-cron');
+
+var valid = cron.validate('59 * * * *');
+var invalid = cron.validate('60 * * * *');
+```
+
 ## Issues
 
 Feel free to submit issues and enhancement requests [here](https://github.com/merencia/node-cron/issues).

--- a/src/node-cron.js
+++ b/src/node-cron.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var Task = require('./task'),
-  ScheduledTask = require('./scheduled-task');
+  ScheduledTask = require('./scheduled-task'),
+  validation = require('./pattern-validation');
 
 module.exports = (function() {
 
@@ -20,7 +21,18 @@ module.exports = (function() {
     return new ScheduledTask(task, immediateStart);
   }
 
+  function validate(expression) {
+    try {
+      validation(expression);
+    } catch(e) {
+      return false;
+    }
+
+    return true;
+  }
+
   return {
-    schedule: createTask
+    schedule: createTask,
+    validate: validate
   };
 }());

--- a/test/validate-test.js
+++ b/test/validate-test.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var expect = require('expect.js');
+var cron = require('../src/node-cron');
+
+describe('public .validate() method', function(){
+  it('should succeed with a valid expression', function() {
+    var result = cron.validate('59 * * * *');
+    expect(result).to.equal(true);
+  });
+
+  it('should fail with an invalid expression', function() {
+    var result = cron.validate('60 * * * *');
+    expect(result).to.equal(false);
+  });
+});


### PR DESCRIPTION
I have a use-case where I need to allow users to submit CRON expressions via an API. Before inserting these expressions into a database they need to be validated.

This PR exposes the internal validation function, though wrapped in a try/catch to make consuming easier.