### PR TITLE
Removing extra spaces in task string

### DIFF
--- a/src/convert-expression/index.js
+++ b/src/convert-expression/index.js
@@ -15,6 +15,10 @@ module.exports = (function() {
     return expressions;
   }
 
+  function removeSpaces(str) {
+    return str.replace(/\s{2,}/g, ' ').trim();
+  }
+
   /*
    * The node-cron core allows only numbers (including multiple numbers e.g 1,2).
    * This module is going to translate the month names, week day names and ranges
@@ -33,7 +37,7 @@ module.exports = (function() {
    *  - Will be translated to 1,2,3,4,5 * * * *
    */
   function interprete(expression){
-    var expressions = expression.split(' ');
+    var expressions = removeSpaces(expression).split(' ');
     expressions = appendSeccondExpression(expressions);
     expressions[4] = monthNamesConversion(expressions[4]);
     expressions[5] = weekDayNamesConversion(expressions[5]);
@@ -43,5 +47,6 @@ module.exports = (function() {
 
     return expressions.join(' ');
   }
+
   return interprete;
 }());

--- a/src/node-cron.js
+++ b/src/node-cron.js
@@ -16,19 +16,23 @@ module.exports = (function() {
    * @returns {ScheduledTask} update function.
    */
   function createTask(expression, func, immediateStart) {
-    var task = new Task(expression, func);
+    var task = new Task( removeSpaces(expression), func );
 
     return new ScheduledTask(task, immediateStart);
   }
 
   function validate(expression) {
     try {
-      validation(expression);
+      validation( removeSpaces(expression) );
     } catch(e) {
       return false;
     }
 
     return true;
+  }
+
+  function removeSpaces(str) {
+    return str.replace(/\s{2,}/g, ' ').trim();
   }
 
   return {

--- a/src/node-cron.js
+++ b/src/node-cron.js
@@ -16,23 +16,19 @@ module.exports = (function() {
    * @returns {ScheduledTask} update function.
    */
   function createTask(expression, func, immediateStart) {
-    var task = new Task( removeSpaces(expression), func );
+    var task = new Task(expression, func);
 
     return new ScheduledTask(task, immediateStart);
   }
 
   function validate(expression) {
     try {
-      validation( removeSpaces(expression) );
+      validation(expression);
     } catch(e) {
       return false;
     }
 
     return true;
-  }
-
-  function removeSpaces(str) {
-    return str.replace(/\s{2,}/g, ' ').trim();
   }
 
   return {

--- a/test/validate-taks-schaduling-test.js
+++ b/test/validate-taks-schaduling-test.js
@@ -20,4 +20,20 @@ describe('validate cron on task schaduling', function(){
       expect(e).to.equal('65 is a invalid expression for minute');
     });
   });
+
+  it('validate some spaces in task string', function(){
+    var result = cron.validate('5    * * * *');
+    expect(result).to.equal(true);
+  });
+
+  it('multiple spaces in task string', function(){
+    var result = cron.validate('5    *    *  *   *');
+    expect(result).to.equal(true);
+  });
+
+  it('spaces in begin and end of string', function(){
+    var result = cron.validate('       5 * *    * *     ');
+    expect(result).to.equal(true);
+  });
+
 });


### PR DESCRIPTION
Some people need write hints for using cron. But 2 and more spaces not valid for module. I fixed it replace multiple spaces on one inside task string. Plus remove spaces in begin, end.
```js
{
  //         m      h       dom    mon    dow
  cron: '    *     */10      *      *      *    '
}
```