### PR TITLE
Adding options and depreciating immediateStart

### DIFF
--- a/src/node-cron.js
+++ b/src/node-cron.js
@@ -15,10 +15,23 @@ module.exports = (function() {
    * @param {boolean} immediateStart - whether to start the task immediately.
    * @returns {ScheduledTask} update function.
    */
-  function createTask(expression, func, immediateStart) {
-    var task = new Task(expression, func);
+  function createTask(expression, func, options) {
+    // Added for immediateStart depreciation
+    if(typeof options === 'boolean'){
+      console.warn('DEPRECIATION: imediateStart is deprecated and will be removed soon in favor of the options param.');
+      options = {
+        scheduled: options
+      }
+    }
+    
+    if(!options){
+      options = {
+        scheduled: true
+      }
+    }
 
-    return new ScheduledTask(task, immediateStart);
+    var task = new Task(expression, func);
+    return new ScheduledTask(task, options);
   }
 
   function validate(expression) {

--- a/src/node-cron.js
+++ b/src/node-cron.js
@@ -21,13 +21,13 @@ module.exports = (function() {
       console.warn('DEPRECIATION: imediateStart is deprecated and will be removed soon in favor of the options param.');
       options = {
         scheduled: options
-      }
+      };
     }
     
     if(!options){
       options = {
         scheduled: true
-      }
+      };
     }
 
     var task = new Task(expression, func);

--- a/src/scheduled-task.js
+++ b/src/scheduled-task.js
@@ -6,16 +6,16 @@ module.exports = (function() {
    * Creates a new scheduled task.
    *
    * @param {Task} task - task to schedule.
-   * @param {boolean} immediateStart - whether to start the task immediately.
+   * @param {*} options - task options.
    */
-  function ScheduledTask(task, immediateStart) {
+  function ScheduledTask(task, options) {
     this.task = function() {
       task.update(new Date());
     };
 
     this.tick = null;
 
-    if (immediateStart !== false) {
+    if (options.scheduled !== false) {
       this.start();
     }
   }


### PR DESCRIPTION
Depreciating immediateStart.

Adding options with `scheduled` to replace immediateStart;

refs #https://github.com/merencia/node-cron/issues/27